### PR TITLE
Correction to stablish the namespace on MARCXML Document

### DIFF
--- a/src/main/java/org/marc4j/MarcXmlWriter.java
+++ b/src/main/java/org/marc4j/MarcXmlWriter.java
@@ -411,6 +411,9 @@ public class MarcXmlWriter implements MarcWriter {
         try {
             final AttributesImpl atts = new AttributesImpl();
             handler.startDocument();
+            this.handler.startPrefixMapping("", Constants.MARCXML_NS_URI);
+            atts.addAttribute(Constants.MARCXML_NS_URI, "xmlns", "xmlns",
+                    "CDATA", Constants.MARCXML_NS_URI);
             handler.startElement(Constants.MARCXML_NS_URI, COLLECTION,
                     COLLECTION, atts);
         } catch (final SAXException e) {


### PR DESCRIPTION
Correction to stablish the XML Document namespace (xmlns) to http://www.loc.gov/MARC21/slim . Previously the generated marcxml namespace was not defined. With this change the user can work altogether with applications provided by Library of Congress like FRBR Display Tool