### PR TITLE
Improved conversion between Unicode/ISO-5426.

### DIFF
--- a/src/main/java/info/freelibrary/marc4j/converter/impl/Iso5426ToUnicode.java
+++ b/src/main/java/info/freelibrary/marc4j/converter/impl/Iso5426ToUnicode.java
@@ -99,13 +99,14 @@ public class Iso5426ToUnicode extends CharConverter {
         return (true);
     }
 
-    // Source : http://www.itscj.ipsj.or.jp/ISO-IR/053.pdf
+    // Source: http://www.unicode.org/L2/L2000/00220-map-5426.pdf
+    // Finalized Mapping between Characters of ISO 5426 and ISO/IEC 10646-1 (UCS)
     private char getChar(final int i) {
         switch (i) {
             case 0xA1:
                 return 0x00A1; // 2/1 inverted exclamation mark
             case 0xA2:
-                return 0x201C; // 2/2 left low double quotation mark
+                return 0x201E; // 2/2 left low double quotation mark
             case 0xA3:
                 return 0x00A3; // 2/3 pound sign
             case 0xA4:
@@ -134,11 +135,11 @@ public class Iso5426ToUnicode extends CharConverter {
                 return 0x00AE; // 2/15 trade mark sign
 
             case 0xB0:
-                return 0x0639; // 3/0 ayn [ain]
+                return 0x02BB; // 3/0 ayn
             case 0xB1:
-                return 0x0623; // 3/1 alif/hamzah [alef with hamza above]
+                return 0x02BC; // 3/1 alif/hamzah
             case 0xB2:
-                return 0x2018; // 3/2 left low single quotation mark
+                return 0x201A; // 3/2 left low single quotation mark
                 // 3/3 (this position shall not be used)
                 // 3/4 (this position shall not be used)
                 // 3/5 (this position shall not be used)
@@ -193,6 +194,10 @@ public class Iso5426ToUnicode extends CharConverter {
                 // 7/0 (this position shall not be used)
             case 0xF1:
                 return 0x00E6; // 7/1 small diphthong a with e
+            case 0xF2:
+                return 0x0111; // 7/2 small letter d with stroke
+            case 0xF3:
+                return 0x00F0; // 7/3 small letter eth
                 // 7/4 (this position shall not be used)
             case 0xF5:
                 return 0x0131; // 7/5 small letter i without dot
@@ -610,6 +615,44 @@ public class Iso5426ToUnicode extends CharConverter {
                 // 4/9 umlaut
             case 0xC920:
                 return 0x00A8; // [diaeresis]
+            case 0xC941:
+                return 0x00C4; // CAPITAL A WITH DIAERESIS
+            case 0xC945:
+                return 0x00CB; // CAPITAL E WITH DIAERESIS
+            case 0xC948:
+                return 0x1E26; // CAPITAL H WITH DIAERESIS
+            case 0xC949:
+                return 0x00CF; // CAPITAL I WITH DIAERESIS
+            case 0xC94F:
+                return 0x00D6; // CAPITAL O WITH DIAERESIS
+            case 0xC955:
+                return 0x00DC; // CAPITAL U WITH DIAERESIS
+            case 0xC957:
+                return 0x1E84; // CAPITAL W WITH DIAERESIS
+            case 0xC958:
+                return 0x1E8C; // CAPITAL X WITH DIAERESIS
+            case 0xC959:
+                return 0x0178; // CAPITAL Y WITH DIAERESIS
+            case 0xC961:
+                return 0x00E4; // small a with diaeresis
+            case 0xC965:
+                return 0x00EB; // small e with diaeresis
+            case 0xC968:
+                return 0x1E27; // small h with diaeresis
+            case 0xC969:
+                return 0x00EF; // small i with diaeresis
+            case 0xC96F:
+                return 0x00F6; // small o with diaeresis
+            case 0xC974:
+                return 0x1E97; // small t with diaeresis
+            case 0xC975:
+                return 0x00FC; // small u with diaeresis
+            case 0xC977:
+                return 0x1E85; // small w with diaeresis
+            case 0xC978:
+                return 0x1E8D; // small x with diaeresis
+            case 0xC979:
+                return 0x00FF; // small y with diaeresis
 
                 // 4/10 circle above
             case 0xCA41:

--- a/src/main/java/info/freelibrary/marc4j/converter/impl/UnicodeToIso5426.java
+++ b/src/main/java/info/freelibrary/marc4j/converter/impl/UnicodeToIso5426.java
@@ -21,6 +21,7 @@
 package info.freelibrary.marc4j.converter.impl;
 
 import org.marc4j.converter.CharConverter;
+import org.marc4j.util.Normalizer;
 
 /**
  * <p>
@@ -45,9 +46,14 @@ public class UnicodeToIso5426 extends CharConverter {
      */
     @Override
     public String convert(final char data[]) {
+        // Conversion does not support "combining diacritical" characters
+        // Must normalize first for correct results
+        final char[] normalizedData = Normalizer.normalize(
+                String.valueOf(data), Normalizer.NFC).toCharArray();
+
         final StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < data.length; i++) {
-            final char c = data[i];
+        for (int i = 0; i < normalizedData.length; i++) {
+            final char c = normalizedData[i];
             if (c < 128) {
                 sb.append(c);
             } else {
@@ -186,6 +192,8 @@ public class UnicodeToIso5426 extends CharConverter {
                 return 0xC369; // small i with circumflex accent
             case 0x00EF:
                 return 0xC869; // small i with diaeresis
+            case 0x00F0:
+                return 0xF3; // 7/3 small letter eth
             case 0x00F1:
                 return 0xC46E; // small n with tilde
             case 0x00F2:
@@ -248,6 +256,8 @@ public class UnicodeToIso5426 extends CharConverter {
                 return 0xCF64; // small d with caron
             case 0x0110:
                 return 0xE2; // 6/2 CAPITAL LETTER D WITH STROKE
+            case 0x0111:
+                return 0xF2; // 7/2 small letter d with stroke
             case 0x0112:
                 return 0xC545; // CAPITAL E WITH MACRON
             case 0x0113:
@@ -500,14 +510,14 @@ public class UnicodeToIso5426 extends CharConverter {
                 return 0xBD; // 3/13 mjagkij znak
             case 0x02BA:
                 return 0xBE; // 3/14 tverdyj znak
+            case 0x02BB:
+                return 0xB0; // 3/0 ayn
+            case 0x02BC:
+                return 0xB1; // 3/1 alif/hamzah
             case 0x02CC:
                 return 0xDA20; // small low vertical bar
             case 0x02DB:
                 return 0xD320; // ogonek
-            case 0x0623:
-                return 0xB1; // 3/1 alif/hamzah [alef with hamza above]
-            case 0x0639:
-                return 0xB0; // 3/0 ayn [ain]
             case 0x1E00:
                 return 0xD441; // CAPITAL A WITH RING BELOW
             case 0x1E01:
@@ -746,16 +756,16 @@ public class UnicodeToIso5426 extends CharConverter {
                 return 0xD920; // double underline
             case 0x2018:
                 return 0xA9; // 2/9 left high single quotation mark
-                // case 0x2018: return 0xB2; // 3/2 left low single quotation
-                // mark
             case 0x2019:
                 return 0xB9; // 3/9 right high single quotation mark
+            case 0x201A:
+                return 0xB2; // 3/2 left low single quotation
             case 0x201C:
-                return 0xA2; // 2/2 left low double quotation mark
-                // case 0x201C: return 0xAA; // 2/10 left high double quotation
-                // mark
+                return 0xAA; // 2/10 left high double quotation mark
             case 0x201D:
                 return 0xBA; // 3/10 right high double quotation mark
+            case 0x201E:
+                return 0xA2; // 2/2 left low double quotation mark
             case 0x2020:
                 return 0xA6; // 2/6 single dagger
             case 0x2021:


### PR DESCRIPTION
Based on http://www.unicode.org/L2/L2000/00220-map-5426.pdf there were
some characters missing and some incorrect for the conversion to/from
Unicode to/from ISO-5426.

In ISO-5426, characters in the range 0xC0-0xDF are used as combining
characters to apply diacritics to the characters that _follow_ them. The
existing code handles these by outputting the normalized,
single-character versions when converting to unicode, and only
supporting normalized unicode input when converting from unicode.
This means that data input to UnicodeToIso5426 needs to be normalized to
get the correct result, so that was added.

Characters 0xC8 and 0xC9 (4/8, 4/9) map to the same unicode character,
u+0308 "combining diaeresis". When converting to ISO-5426, current code
always uses the 0xC8 vairent when converting the normalized version of
<some-char> + u+0308.  The reverse conversion back to unicode had no
support for 0xC9 characters even though this is legal. Now 0xC9
preceding a character will produce the same unicode character as 0xC8
preceding a character would.

Mappings for ISO-5426 characters 0xF2 and 0xF3 (7/2, 7/3) were missing
in both directions.

Mappings for ISO-5426 characters 0xA2, 0xAA, 0xB0, 0xB1, and 0xB2 (2/2,
2/10, 3/0, 3/1, 3/2) were either wrong or missing in one direction.