### PR TITLE
Add Iterator/Iterable/Stream decorator classes for Java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compiler.version}</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
         <executions>
           <execution>
             <id>codetable-compile</id>

--- a/src/main/java/org/marc4j/RecordIterable.java
+++ b/src/main/java/org/marc4j/RecordIterable.java
@@ -1,0 +1,56 @@
+package org.marc4j;
+
+import org.marc4j.marc.Record;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * Decorator to allow MarcReader instances to be used as <code>Iterable</code>s (e.g. in foreach loops).
+ * <p>Implementation note: delegates to <code>ReccordIterator</code> for most of its functionality.</p>
+ */
+public class RecordIterable implements Iterable<Record> {
+
+    private boolean used = false;
+
+    private RecordIterator iterator;
+
+    /**
+     * Creates a new instance wrapping a supplied reader.
+     * @param reader the reader to be decorated.
+     */
+    public RecordIterable(MarcReader reader) {
+        this.iterator = new RecordIterator(reader);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public Iterator<Record> iterator() {
+        if ( used  ) {
+            throw new IllegalStateException("Unable to read more than once");
+        }
+        used = true;
+        return iterator;
+
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void forEach(Consumer<? super Record> action) {
+        iterator.forEachRemaining(action);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public Spliterator<Record> spliterator() {
+        return iterator.getSpliterator();
+    }
+}

--- a/src/main/java/org/marc4j/RecordIterable.java
+++ b/src/main/java/org/marc4j/RecordIterable.java
@@ -14,13 +14,13 @@ public class RecordIterable implements Iterable<Record> {
 
     private boolean used = false;
 
-    private RecordIterator iterator;
+    private final RecordIterator iterator;
 
     /**
      * Creates a new instance wrapping a supplied reader.
      * @param reader the reader to be decorated.
      */
-    public RecordIterable(MarcReader reader) {
+    public RecordIterable(final MarcReader reader) {
         this.iterator = new RecordIterator(reader);
     }
 
@@ -42,7 +42,7 @@ public class RecordIterable implements Iterable<Record> {
      * @inheritDoc
      */
     @Override
-    public void forEach(Consumer<? super Record> action) {
+    public void forEach(final Consumer<? super Record> action) {
         iterator.forEachRemaining(action);
     }
 

--- a/src/main/java/org/marc4j/RecordIterator.java
+++ b/src/main/java/org/marc4j/RecordIterator.java
@@ -40,10 +40,17 @@ public class RecordIterator implements Iterator<Record> {
 
     private final MarcReader wrappedReader;
 
+    private final static int SPLITERATOR_CHARACTERISTICS =  Spliterator.ORDERED |
+            Spliterator.DISTINCT |
+            Spliterator.IMMUTABLE;
 
     private boolean used = false;
 
-    public RecordIterator(MarcReader wrappedReader) {
+    /**
+     * Create a new instance that decorates the supplied reader.
+     * @param wrappedReader the reader to be decorated.
+     */
+    public RecordIterator(final MarcReader wrappedReader) {
         this.wrappedReader = wrappedReader;
     }
 
@@ -76,8 +83,8 @@ public class RecordIterator implements Iterator<Record> {
      * @inheritDoc
      */
     @Override
-    public void forEachRemaining(Consumer<? super Record> action) {
-        while( wrappedReader.hasNext() ) {
+    public void forEachRemaining(final Consumer<? super Record> action) {
+        while ( wrappedReader.hasNext() ) {
             action.accept(wrappedReader.next());
         }
     }
@@ -95,7 +102,7 @@ public class RecordIterator implements Iterator<Record> {
     }
 
     protected Spliterator<Record> getSpliterator() {
-        return Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
+        return Spliterators.spliteratorUnknownSize(this, SPLITERATOR_CHARACTERISTICS);
     }
 
 }

--- a/src/main/java/org/marc4j/RecordIterator.java
+++ b/src/main/java/org/marc4j/RecordIterator.java
@@ -1,0 +1,101 @@
+package org.marc4j;
+
+import org.marc4j.marc.Record;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Decorator for <code>MarcReader</code> objects that implements <code>Iterator</code>, and provides
+ * methods for creating <code>Iterable</code> and <code>Stream</code> instances from the underlying reader.
+ *
+ * <p>
+ *     Example usage:
+ *
+ *     <code>
+ *         try( BufferedInputStream input = new BufferedInputStream( new FileInputSream("marc.xml") ) ) {
+ *             MarcXmlReader reader = new MarcXmlReader(input);
+ *             new RecordInterator(reader).forEach( (rec) -> {
+
+ *              };
+ *          }</code>
+ * </p>
+ *     <code>
+ *         // assuming you know you have 245$a in all records ...
+ *          List<String> titles = new RecordIterator(reader).toStream()
+ *              .map( rec -> ((DataField)rec.getVariableField("245")).getSubfield('a").getValue()) )
+ *              .filter( s -> s.contains("Badgers")
+ *              .collect( Collectors.toList() );
+ *     </code>
+ * </p>
+ *
+ * @see MarcReader
+ * @see Iterator
+ */
+public class RecordIterator implements Iterator<Record> {
+
+    private final MarcReader wrappedReader;
+
+
+    private boolean used = false;
+
+    public RecordIterator(MarcReader wrappedReader) {
+        this.wrappedReader = wrappedReader;
+    }
+
+    /**
+     * @inheritDoc
+     * @return
+     */
+    @Override
+    public boolean hasNext() {
+        return wrappedReader.hasNext();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public Record next() {
+        return wrappedReader.next();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove() not supported on this class");
+    }
+
+    /*
+     * @inheritDoc
+     */
+    @Override
+    public void forEachRemaining(Consumer<? super Record> action) {
+        while( wrappedReader.hasNext() ) {
+            action.accept(wrappedReader.next());
+        }
+    }
+
+    /**
+     * Adapt the underlying <code>MarcReader</code> as a Stream.
+     * <p>
+     *     Due to the properties of the underlying <code>MarcReader</code>, the stream is of unknown size,
+     *     ordered, and immutable.
+     * </p></p>
+     * @return a sequence of records.
+     */
+    public Stream<Record> toStream() {
+        return StreamSupport.stream( getSpliterator(), false);
+    }
+
+    protected Spliterator<Record> getSpliterator() {
+        return Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
+    }
+
+}

--- a/src/test/java/info/freelibrary/marc4j/utils/ResourceLoadUtils.java
+++ b/src/test/java/info/freelibrary/marc4j/utils/ResourceLoadUtils.java
@@ -1,0 +1,60 @@
+package info.freelibrary.marc4j.utils;
+
+import org.marc4j.*;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+
+/**
+ * A set of utilities for loading test record files from the classpath.
+ */
+public class ResourceLoadUtils {
+
+
+    // get a buffered input stream from a named classpath resource.
+    public static InputStream readResource(String resource) {
+        return new BufferedInputStream(ResourceLoadUtils.class.getResourceAsStream(resource));
+    }
+
+    /**
+     * Get a marc stream reader set to 'permissive' and which converts to UTF-8
+     * @param resource
+     * @return
+     */
+    public static MarcReader getPermissiveMarc21Reader(String resource) {
+        return new MarcPermissiveStreamReader(readResource(resource), true, true);
+    }
+
+    /**
+     * Get a (non-permissive) MarcStreamReader on the specified classpath resource.
+     * @param resource
+     * @return
+     */
+    public static MarcReader getMARC21Reader(String resource) {
+        return new MarcStreamReader(readResource(resource));
+    }
+
+    public static MarcReader getMARCXMLReader(String resource) {
+        return new MarcXmlReader(readResource(resource));
+    }
+
+    public static MarcReader getMARCInJSONReader(String resource) {
+        return new MarcJsonReader(readResource(resource));
+    }
+
+
+    public static MarcReader getMarcReader(String resource) {
+        String ext = resource.substring( resource.lastIndexOf(".") + 1 );
+        switch( ext.toLowerCase() ) {
+            case "xml":
+                return getMARCXMLReader(resource);
+            case "mrc":
+                return getMARC21Reader(resource);
+            case "json":
+                return getMARCInJSONReader(resource);
+            default:
+                return getMARC21Reader(resource);
+        }
+    }
+
+}

--- a/src/test/java/org/marc4j/RecordIterableTest.java
+++ b/src/test/java/org/marc4j/RecordIterableTest.java
@@ -1,0 +1,27 @@
+package org.marc4j;
+
+import info.freelibrary.marc4j.utils.StaticTestRecords;
+import org.junit.Test;
+import org.marc4j.marc.Record;
+
+import static info.freelibrary.marc4j.utils.ResourceLoadUtils.getMARCXMLReader;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for <code>RecordIterable</code>
+ */
+public class RecordIterableTest {
+
+    @Test
+    public void testCount() {
+        int EXPECTED_COUNT = 1;
+        String testFile = StaticTestRecords.RESOURCES_OCLC814388508_XML;
+        RecordIterable instance =  new RecordIterable(getMARCXMLReader(testFile));
+        int count = 0;
+        for( Record rec : instance ) {
+            count++;
+        }
+        assertEquals("Unexpected number of records in " + testFile, EXPECTED_COUNT, count);
+    }
+
+}

--- a/src/test/java/org/marc4j/RecordIteratorTest.java
+++ b/src/test/java/org/marc4j/RecordIteratorTest.java
@@ -1,0 +1,107 @@
+package org.marc4j;
+
+import info.freelibrary.marc4j.utils.StaticTestRecords;
+import org.junit.Test;
+import org.marc4j.marc.DataField;
+import org.marc4j.marc.Record;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static info.freelibrary.marc4j.utils.ResourceLoadUtils.getMARC21Reader;
+import static info.freelibrary.marc4j.utils.ResourceLoadUtils.getMARCXMLReader;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests (and examples) for the <code>RecordIterator</code> class.
+ */
+public class RecordIteratorTest {
+
+
+    private List<String> chabonTitles = Arrays.asList("The amazing adventures of Kavalier and Clay :", "Summerland /");
+
+    private Map<String, Integer> expectedCounts = new HashMap<>();
+
+
+    public RecordIteratorTest() {
+        expectedCounts.put(StaticTestRecords.RESOURCES_CHABON_MRC, 2);
+        expectedCounts.put(StaticTestRecords.RESOURCES_CHABON_XML, 2);
+    }
+
+    private int countRecords(RecordIterator iterator) {
+        int count = 0;
+        while (iterator.hasNext() ) {
+            count++;
+            iterator.next();
+        }
+        return count;
+    }
+
+
+    @Test
+    public void testForEachRemaining() {
+        List<String> titles = new ArrayList<>();
+        String testFile = StaticTestRecords.RESOURCES_CHABON_XML;
+        RecordIterator instance = new RecordIterator( getMARCXMLReader(testFile) );
+        instance.forEachRemaining( (rec) -> titles.add( getTitle(rec) ) );
+        for(int i = 0, n = titles.size();i<n; i++ ) {
+            assertEquals("Found unexpected title #" + i + " in " + testFile, chabonTitles.get(i), titles.get(i));
+        }
+    }
+
+
+    @Test
+    public void testSpliterator() {
+        List<String> titles = new ArrayList<>();
+        String testFile = StaticTestRecords.RESOURCES_CHABON_XML;
+        RecordIterator instance = new RecordIterator( getMARCXMLReader(testFile) );
+        int characteristics = instance.getSpliterator().characteristics();
+        assertEquals("Spliterator should not be sized",0, characteristics & Spliterator.SIZED);
+        assertEquals("Spliterator should not be subsized",0, characteristics & Spliterator.SUBSIZED);
+        assertEquals("Spliterator should be distinct", Spliterator.DISTINCT, characteristics & Spliterator.DISTINCT);
+        assertEquals("Spliterator shoudl be immutable", Spliterator.IMMUTABLE, characteristics & Spliterator.IMMUTABLE);
+    }
+
+    @Test
+    public void testCountXML() {
+        String testFile = StaticTestRecords.RESOURCES_CHABON_XML;
+        int EXPECTED_COUNT = expectedCounts.get(testFile);
+        RecordIterator instance = new RecordIterator( getMARCXMLReader(testFile) );
+        assertEquals("Unexpected count of records in " + testFile, EXPECTED_COUNT, countRecords(instance));
+    }
+
+    @Test
+    public void testCountStreamReader() {
+        String testFile = StaticTestRecords.RESOURCES_CHABON_MRC;
+        int EXPECTED_COUNT = expectedCounts.get(testFile);
+        RecordIterator iterator = new RecordIterator( getMARC21Reader( testFile ) );
+        assertEquals("Unexpected count of records in " + testFile, EXPECTED_COUNT, countRecords(iterator));
+    }
+
+    @Test
+    public void testStreamCount() {
+
+        String testFile = StaticTestRecords.RESOURCES_CHABON_MRC;
+        long EXPECTED_COUNT = (long)expectedCounts.get(testFile);
+        RecordIterator iterator = new RecordIterator( getMARC21Reader(testFile) );
+        long streamCount =  iterator.toStream().count();
+        assertEquals("Unexpected number of records in " + testFile , EXPECTED_COUNT, streamCount);
+    }
+
+    @Test
+    public void testTitles() {
+        String testFile = StaticTestRecords.RESOURCES_CHABON_MRC;
+        RecordIterator iterator = new RecordIterator( getMARC21Reader(testFile) );
+        List<String> titles = iterator.toStream().map(RecordIteratorTest::getTitle).collect( Collectors.toList() );
+        assertEquals("Found unexpected title count in " + testFile, (long)expectedCounts.get(testFile), titles.size() );
+        for(int i = 0, n = titles.size();i<n; i++ ) {
+            assertEquals("Found unexpected title #" + i + " in " + testFile, chabonTitles.get(i), titles.get(i));
+        }
+    }
+
+    private static String getTitle(Record rec) {
+        return ((DataField) rec.getVariableField("245")).getSubfieldsAsString("a");
+    }
+
+
+}


### PR DESCRIPTION
#19 This PR contains two commits; one that sets the compiler source and target to 1.8 so Java 8 classes and syntax can be used, and another that adds two classes to the org.marc4j package:

`RecordIterator` - decorator for MarcReader instances that implements Iterator interface and adds a toStream` method so readers can be read using Java 8 stream features.

`RecordIterable` - decorator for `MarcReader` instances that allows foreach loops.

Includes basic unit tests for the new features (and a utility class for use in unit tests)